### PR TITLE
Add CS6035 malware analysis research extension

### DIFF
--- a/projects/malware-analysis.html
+++ b/projects/malware-analysis.html
@@ -204,6 +204,135 @@ sequenceDiagram
                     <li>Automate Android command inference using differential fuzzing of BroadcastReceivers.</li>
                 </ul>
             </div>
+
+            <section id="cs6035-malware-analysis" class="section">
+                <h2>CS6035 Malware Analysis Project — Behavioral Analysis & Malware Clustering</h2>
+
+                <p class="lead">
+                    This graduate project extends my prior malware work by combining <strong>dynamic sandbox analysis</strong> (Phase&nbsp;1) with <strong>machine-learning–based clustering and classification</strong> (Phase&nbsp;2). It demonstrates end-to-end skills from safe execution and behavior labeling to feature engineering, hierarchical clustering, and F1‑based evaluation.
+                </p>
+
+                <h3>Overview of the Two-Phase Structure</h3>
+                <p>
+                    In <strong>Phase 1</strong>, I performed <em>behavioral malware analysis</em> using Joe&nbsp;Sandbox Cloud, focusing on runtime actions (file/registry modifications, network beacons, process injection). In <strong>Phase 2</strong>, I used <em>Malheur</em> to cluster thousands of sandbox behavior traces and classify new samples by family, targeting a <strong>≥ 70% F1‑score</strong> on a held‑out test set.
+                </p>
+
+                <figure class="diagram">
+                    <pre class="mermaid" aria-label="Pipeline from sandboxing to machine-learning-based detection">
+flowchart LR
+  A[Malware Samples] --> B[Joe Sandbox Cloud<br/>(Dynamic Analysis)]
+  B --> C[Detailed Behavior Reports]
+  C --> D[Analyst Labels Behaviors<br/>(Phase 1)]
+  C --> E[Extract API Call Sequences<br/>for ML Features]
+  E --> F[Malheur Clustering<br/>(Phase 2 Training)]
+  F --> G[Malheur Classification<br/>(Phase 2 Testing)]
+  G --> H[Trained Model (≥70% F‑score)]
+  H --> I[Classify New Malware Samples]
+                    </pre>
+                    <figcaption>Figure 1 — Pipeline from sandboxing to machine‑learning‑based detection.</figcaption>
+                </figure>
+
+                <h3>Phase 1 — Behavioral Malware Analysis (Joe Sandbox Cloud)</h3>
+                <h4>Background & Goals</h4>
+                <p>
+                    Five real‑world samples were analyzed via Joe Sandbox reports to identify behaviors such as file drops, registry persistence, network communication, and potential keylogging/anti‑VM traits. The deliverable was a behavior label set per sample across ~20 categories.
+                </p>
+
+                <h4>Tools & Dataset</h4>
+                <ul>
+                    <li>JoeSandboxCloud reports (process/API call traces, created files, registry/network activity, signatures)</li>
+                    <li>Analyst checklist for behavior questions (e.g., autostart keys, HTTP without user‑agent, keylogging attempts)</li>
+                </ul>
+
+                <h4>Methodology</h4>
+                <ul>
+                    <li>Read <em>Behavior/Processes</em>, <em>Created Files</em>, <em>Registry</em>, <em>Network</em>, and <em>Signatures</em> sections.</li>
+                    <li>Correlate signatures (e.g., sandbox evasion, keylogger) with raw API traces for confirmation.</li>
+                    <li>Count behaviors as “attempted” if invoked by any spawned process, even if OS denied them.</li>
+                </ul>
+
+                <h4>Observations & Results</h4>
+                <ul>
+                    <li>Multiple samples dropped executables/DLLs; registry <code>Run</code> keys used for persistence.</li>
+                    <li>Network beacons included HTTP GETs with missing user‑agent; DNS lookups and socket ops observed.</li>
+                    <li>Keylogging indicators via low‑level keyboard/clipboard APIs; anti‑VM/environment checks present.</li>
+                </ul>
+
+                <h4>Limitations & Challenges</h4>
+                <ul>
+                    <li>Information overload in long traces—relied on filtering/keyword search and sequence context.</li>
+                    <li>Runtime‑only vantage point: behaviors not triggered in sandbox remain unseen.</li>
+                </ul>
+
+                <h3>Phase 2 — Malware Clustering & Classification (Malheur)</h3>
+                <h4>Background & Goals</h4>
+                <p>
+                    Using Malheur, I clustered behavior sequences (event streams of API calls) to discover families and then classified hold‑out/test samples, targeting ≥ 0.70 F1 on the test set and zero rejected subjects (<code>classify.max_dist=1.0</code>).
+                </p>
+
+                <h4>Tools, Data & Config</h4>
+                <ul>
+                    <li><strong>Data:</strong> &gt;11k training feature files and a separate testing set; each file encodes a semicolon‑separated API call sequence.</li>
+                    <li><strong>Labels:</strong> Ground truth via AVClass/VirusTotal family tags embedded as pseudo file extensions (e.g., <code>.dinwod</code>).</li>
+                    <li><strong>Key params:</strong> <code>ngram_len</code> for sequential context; <code>classify.max_dist=1.0</code> to avoid “rejected”.</li>
+                </ul>
+
+                <h4>Methodology</h4>
+                <ul>
+                    <li><em>Vectorization:</em> map event sequences to n‑gram feature vectors.</li>
+                    <li><em>Training:</em> hierarchical/agglomerative clustering → cluster prototypes.</li>
+                    <li><em>Tuning:</em> iterate <code>ngram_len</code>/distance settings to balance precision vs. recall.</li>
+                    <li><em>Testing:</em> nearest‑prototype classification on the test set; compute precision/recall/F1.</li>
+                    <li><em>Subjects:</em> classify Phase‑1 samples; ensure none are rejected.</li>
+                </ul>
+
+                <figure class="diagram">
+                    <pre class="mermaid" aria-label="Malheur training and classification workflow">
+flowchart TD
+  subgraph Training
+    A["Training Feature Files<br/>(API sequences)"] --> B[Vectorization (n‑grams)]
+    B --> C[Hierarchical Clustering]
+    C --> D{{Clusters}}
+    D --> E[Cluster Prototypes (Model)]
+    D --> F([Evaluate Precision / Recall / F1])
+  end
+  subgraph Testing
+    G["Testing Feature Files"] --> H[Vectorization]
+    H --> I[Assign to Nearest Prototype]
+    I --> J([Classification Results])
+    J --> K([Compute F1 on Test Set])
+  end
+                    </pre>
+                    <figcaption>Figure 2 — Malheur training/classification workflow.</figcaption>
+                </figure>
+
+                <h4>Results</h4>
+                <ul>
+                    <li>Achieved <strong>~0.70 F1</strong> on the test set; all subject samples classified (no “rejected”).</li>
+                    <li>High‑purity clusters aligned with known families (e.g., Dinwod, Mirai‑like network behavior).</li>
+                </ul>
+
+                <h4>Limitations & Challenges</h4>
+                <ul>
+                    <li>Family overlap in common behaviors; need sequential context (n‑grams) to disambiguate.</li>
+                    <li>High‑dimensional feature space; clustering at scale requires careful parameter choices.</li>
+                    <li>Label noise from AV aggregation; interpret cluster IDs with threat‑intel cross‑checks.</li>
+                </ul>
+
+                <h3>Key Security Skills Demonstrated</h3>
+                <ul class="skills">
+                    <li>Sandboxed malware execution & behavior triage</li>
+                    <li>Behavior labeling & indicator extraction</li>
+                    <li>Feature engineering on event sequences (n‑grams)</li>
+                    <li>Unsupervised learning (hierarchical clustering)</li>
+                    <li>Model evaluation (precision/recall/F1)</li>
+                    <li>Scripting & automation for iterative tuning</li>
+                </ul>
+
+                <p class="note">This section complements my earlier CS6262 analysis by adding a scalable, ML‑driven approach to family discovery and classification.</p>
+            </section>
+
+            <p><a href="../index.html#projects">Back to Projects</a> | <a href="#cs6035-malware-analysis">CS6035 Research Extension</a></p>
         </section>
     </main>
 
@@ -212,9 +341,13 @@ sequenceDiagram
             <p>&copy; 2025 Mason Kim. All rights reserved.</p>
         </div>
     </footer>
-    <script type="module">
-        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-        mermaid.initialize({ startOnLoad: true });
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js" defer></script>
+    <script defer>
+        document.addEventListener('DOMContentLoaded', () => {
+            if (window.mermaid) {
+                mermaid.initialize({ startOnLoad: true, theme: 'dark' });
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- append CS6035 project section detailing behavioral analysis and ML clustering
- add navigation link to new section and back-to-projects anchor
- enable dark-themed Mermaid initialization for diagrams

## Testing
- `npx --yes htmlhint projects/malware-analysis.html` *(fails: special characters must be escaped in Mermaid diagrams)*

------
https://chatgpt.com/codex/tasks/task_e_689647795d9083309810bd9e76e9de47